### PR TITLE
implement subthemes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/.bin/ember",
+      "stopOnEntry": false,
+      "args": ["build"],
+      "cwd": "${workspaceRoot}",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "externalConsole": false,
+      "sourceMaps": false,
+      "outDir": null
+    },
+    {
+      "name": "Attach",
+      "type": "node",
+      "request": "attach",
+      "port": 5858,
+      "address": "localhost",
+      "restart": false,
+      "sourceMaps": false,
+      "outDir": null,
+      "localRoot": "${workspaceRoot}",
+      "remoteRoot": null
+    }
+  ]
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,1 +1,3 @@
+// TODO tomato import base dependency once preprocessors allow it
 @import 'ui-base-theme';
+@import 'ui-tomato-theme';

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "^0.2.9",
-    "ember-cli-sass": "5.3.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -40,6 +39,9 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1",
-    "ui-base-theme": "prototypal-io/ui-base-theme"
+    "ui-tomato-theme": "prototypal-io/ui-tomato-theme"
+  },
+  "dependencies": {
+    "ember-cli-sass": "^5.3.1"
   }
 }


### PR DESCRIPTION
This commit utilizes the ui-tomato-theme for testing subtheme functionality. Also includes:
- scss imports from the theme scss files
- vscode debugging support
- switched dependency from ui-base-theme to ui-tomato-theme
